### PR TITLE
adding fixes for issue #28, expanded some code for debuggability, minor fixes

### DIFF
--- a/source/mxj/JavaHomeOsx.c
+++ b/source/mxj/JavaHomeOsx.c
@@ -48,8 +48,8 @@ char   dirSeparator  = '/';
 
 #define JAVA_FRAMEWORK "/System/Library/Frameworks/JavaVM.framework"
 
-#define MAX_LOCATION_LENGTH 40 /* none of the jvmLocations strings should be longer than this */
-#define MAX_JVMLIB_LENGTH   15 /* none of the jvmLibs strings should be longer than this */
+#define MAX_LOCATION_LENGTH 100 /* none of the jvmLocations strings should be longer than this */
+#define MAX_JVMLIB_LENGTH   100 /* none of the jvmLibs strings should be longer than this */
 static const char* jvmLocations[] = {
     "../lib/" JAVA_ARCH "/client",
     "../lib/" JAVA_ARCH "/server",
@@ -62,7 +62,7 @@ static const char* jvmLocations[] = {
     "../bundle/Libraries",
     NULL
 };
-static const char* jvmLibs[] = { "libjvm.dylib", "libjvm.jnilib", "libjvm.so", NULL };
+static const char* jvmLibs[] = { "libclient64.dylib","libjvm.dylib", "libjvm.jnilib", "libjvm.so", NULL };
 
 /* Define the window system arguments for the various Java VMs. */
 static char*  argVM_JAVA[] = { "-XstartOnFirstThread", NULL };

--- a/source/mxj/JavaHomeOsx.h
+++ b/source/mxj/JavaHomeOsx.h
@@ -21,6 +21,6 @@ char * getJavaHome();
 char * getJavaJli();
 char * findVMLibrary( char* command );
 char * findLib( char* command );
-
+int isVMLibrary( _TCHAR* vm );
 
 #endif /* defined(__mxj__JavaHomeOsx__) */

--- a/source/mxj/maxjava.c
+++ b/source/mxj/maxjava.c
@@ -582,19 +582,19 @@ void *maxjava_new(t_symbol *s, short argc, t_atom *argv)
 		
 		rl = PMO_GetCFRunLoopFromEventLoop(PMO_GetCurrentEventLoop());
 		if (!exists) { // only do this for the first one of mxj or mxj~ loaded -jkc
-//			t_symbol *ps_sched_disablequeue = gensym("sched_disablequeue"); 
-//			method sched_disablequeue = (method) ps_sched_disablequeue->s_thing; 
-//			long oldval; 
-//			init_awt();
-//			// a very hacky way to make sure that awt is already initialized on the other thread
-//			// this prevents a hang on OS X 10.9 Mavericks
-//			systhread_sleep(2000);
-//			// we disable queue servicing while running the run loop here 
-//			if (sched_disablequeue)
-//				oldval = (long) (*sched_disablequeue)((void*) 1); 
-//			PMO_CFRunLoopRun();//enter CF runloop so cocoa can call back to us. Thread spawned in init_awt will break us out.
-//			if (sched_disablequeue)
-//				(*sched_disablequeue)((void*) oldval); 
+			t_symbol *ps_sched_disablequeue = gensym("sched_disablequeue"); 
+			method sched_disablequeue = (method) ps_sched_disablequeue->s_thing; 
+			long oldval; 
+			init_awt();
+			// a very hacky way to make sure that awt is already initialized on the other thread
+			// this prevents a hang on OS X 10.9 Mavericks
+			systhread_sleep(2000);
+			// we disable queue servicing while running the run loop here 
+			if (sched_disablequeue)
+				oldval = (long) (*sched_disablequeue)((void*) 1); 
+			PMO_CFRunLoopRun();//enter CF runloop so cocoa can call back to us. Thread spawned in init_awt will break us out.
+			if (sched_disablequeue)
+				(*sched_disablequeue)((void*) oldval); 
 		}
 #endif	//MAC_VERSION
 	} else {


### PR DESCRIPTION
I added back CFRUNLOOP handling that was originally in place and fixed a problem with launching the wrong libjvm for Apple Java 1.6, as it turns out libjvm.dylib points to only a 32 bit version of the library whereas libclient64.dylib pints to the universal library that we actually want. These fixes have shown promise with initial development testing , the launcher will preferentially select a 1.8 java if it is there alongside 1.6, it can run without 1.6 and with only 1.6 in both 32 and 64 bit modes.
