### PR TITLE
added AWT hack switch for 1.6 versus openjdk, more verbose sys props

### DIFF
--- a/source/mxj/IVirtualMachine.cpp
+++ b/source/mxj/IVirtualMachine.cpp
@@ -32,6 +32,30 @@ typedef _JNI_IMPORT_OR_EXPORT_ jint  (*WRAPPED_JNI_GetCreatedJavaVMs)(JavaVM **,
 #include <dlfcn.h>
 
 
+
+// library handle for calling objc_registerThreadWithCollector()
+// without static linking to the libobjc library
+#define OBJC_LIB "/usr/lib/libobjc.dylib"
+#define OBJC_GCREGISTER "objc_registerThreadWithCollector"
+typedef void (*objc_registerThreadWithCollector_t)();
+extern "C" objc_registerThreadWithCollector_t objc_registerThreadWithCollectorFunction;
+objc_registerThreadWithCollector_t objc_registerThreadWithCollectorFunction = NULL;
+
+extern "C"{
+static bool awtLoaded = false;
+static pthread_mutex_t awtLoaded_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  awtLoaded_cv = PTHREAD_COND_INITIALIZER;
+
+JNIEXPORT void JNICALL
+JLI_NotifyAWTLoaded()
+{
+    pthread_mutex_lock(&awtLoaded_mutex);
+    awtLoaded = true;
+    pthread_cond_signal(&awtLoaded_cv);
+    pthread_mutex_unlock(&awtLoaded_mutex);
+}
+}
+
 #endif
 
 using namespace std;
@@ -146,7 +170,6 @@ void IVirtualMachine::startJava()
 
     pthread_attr_destroy(&attr);
 
-    
 
 
 #endif
@@ -222,6 +245,12 @@ void IVirtualMachine::startJVM()
     
 #ifdef MAC_VERSION
     
+    // dynamically link to objective c gc registration
+    void *handleLibObjc = dlopen(OBJC_LIB, RTLD_LAZY);
+    if (handleLibObjc != NULL) {
+        objc_registerThreadWithCollectorFunction = (objc_registerThreadWithCollector_t) dlsym(handleLibObjc, OBJC_GCREGISTER);
+    }
+    
     char * baseDir = getJavaHome();
     char * dylib = findLib(baseDir);
     char * jli = getJavaJli();
@@ -240,11 +269,11 @@ void IVirtualMachine::startJVM()
     //the jvm can still launch if jli is not present
     //in the case of Apple java 1.6 for example this will not result in a problem
     if(jli!= NULL)
-        dlopen(jli, RTLD_NOW);
+        dlopen(jli, RTLD_NOW + RTLD_GLOBAL);
     
     if(dylib!=NULL)
     {
-        handle= dlopen(dylib,RTLD_NOW);
+        handle= dlopen(dylib,RTLD_NOW + RTLD_GLOBAL);
         if(handle==NULL)
         {
             return;
@@ -260,6 +289,45 @@ void IVirtualMachine::startJVM()
 }
 
 
+jstring IVirtualMachine::getSystemProperty(string propertyName)
+{
+    jstring rval = NULL;
+    
+    IVirtualMachine * myMachine = IVirtualMachine::getInstance();
+    //let's try some awt launching stuff here
+    JNIEnv* env =myMachine->attachJNIThread();
+    if(env!=NULL)
+    {
+        jclass sysClass = env->FindClass("java/lang/System");
+        if(!sysClass){
+            myMachine->exceptionCheck(env, 0);
+        }
+        
+        jmethodID sysGetProperty = env->GetStaticMethodID(sysClass, "getProperty", "(Ljava/lang/String;)Ljava/lang/String;");
+        if(!sysGetProperty){
+            myMachine->exceptionCheck(env, 1,sysClass);
+            return rval;
+        }
+        
+        jstring propName = env->NewStringUTF(propertyName.c_str());
+        
+        
+        rval = (jstring)env->CallStaticObjectMethod(sysClass, sysGetProperty,propName);
+        
+        
+        
+        if(myMachine->exceptionCheck(env, 2,sysClass,propName))
+        {
+            return NULL;
+        }
+        
+        myMachine->cleanUpObjects(env, 2, propName, sysClass);
+    }
+    
+
+    
+    return rval;
+}
 
 
 #ifdef WIN_VERSION
@@ -655,6 +723,190 @@ JNIEnv * IVirtualMachine::attachJNIThread()
 }
 
 
+
+
+void _append_exception_trace_messages(
+                                      JNIEnv&      a_jni_env,
+                                      std::string& a_error_msg,
+                                      jthrowable   a_exception,
+                                      jmethodID    a_mid_throwable_getCause,
+                                      jmethodID    a_mid_throwable_getStackTrace,
+                                      jmethodID    a_mid_throwable_toString,
+                                      jmethodID    a_mid_frame_toString)
+{
+    // Get the array of StackTraceElements.
+    jobjectArray frames =
+    (jobjectArray) a_jni_env.CallObjectMethod(
+                                              a_exception,
+                                              a_mid_throwable_getStackTrace);
+    jsize frames_length = a_jni_env.GetArrayLength(frames);
+    
+    // Add Throwable.toString() before descending
+    // stack trace messages.
+    if (0 != frames)
+    {
+        jstring msg_obj =
+        (jstring) a_jni_env.CallObjectMethod(a_exception,
+                                             a_mid_throwable_toString);
+        const char* msg_str = a_jni_env.GetStringUTFChars(msg_obj, 0);
+        
+        // If this is not the top-of-the-trace then
+        // this is a cause.
+        if (!a_error_msg.empty())
+        {
+            a_error_msg += "\nCaused by: ";
+            a_error_msg += msg_str;
+        }
+        else
+        {
+            a_error_msg = msg_str;
+        }
+        
+        a_jni_env.ReleaseStringUTFChars(msg_obj, msg_str);
+        a_jni_env.DeleteLocalRef(msg_obj);
+    }
+    
+    // Append stack trace messages if there are any.
+    if (frames_length > 0)
+    {
+        jsize i = 0;
+        for (i = 0; i < frames_length; i++)
+        {
+            // Get the string returned from the 'toString()'
+            // method of the next frame and append it to
+            // the error message.
+            jobject frame = a_jni_env.GetObjectArrayElement(frames, i);
+            jstring msg_obj =
+            (jstring) a_jni_env.CallObjectMethod(frame,
+                                                 a_mid_frame_toString);
+            
+            const char* msg_str = a_jni_env.GetStringUTFChars(msg_obj, 0);
+            
+            a_error_msg += "\n    ";
+            a_error_msg += msg_str;
+            
+            a_jni_env.ReleaseStringUTFChars(msg_obj, msg_str);
+            a_jni_env.DeleteLocalRef(msg_obj);
+            a_jni_env.DeleteLocalRef(frame);
+        }
+    }
+    
+    // If 'a_exception' has a cause then append the
+    // stack trace messages from the cause.
+    if (0 != frames)
+    {
+        jthrowable cause =
+        (jthrowable) a_jni_env.CallObjectMethod(
+                                                a_exception,
+                                                a_mid_throwable_getCause);
+        if (0 != cause)
+        {
+            _append_exception_trace_messages(a_jni_env,
+                                             a_error_msg,
+                                             cause,
+                                             a_mid_throwable_getCause,
+                                             a_mid_throwable_getStackTrace,
+                                             a_mid_throwable_toString,
+                                             a_mid_frame_toString);
+        }
+    }
+}
+
+
+/** Error reporting with jboject cleanup)
+ pass any jobjects that need to be cleaned out on error
+ @parameter env - the JNI Environment
+ @parameter numCleanups - the number of open objects to delete
+ @parameter ... - cvariable list of objects to delete local reference
+ returns true if errors were encountered
+ */
+bool IVirtualMachine::exceptionCheck(JNIEnv * env,int numCleanups,...)
+{
+    // Get the exception and clear as no
+    // JNI calls can be made while an exception exists.
+    jthrowable exception = env->ExceptionOccurred();
+    if (exception != NULL)
+    {
+        
+        env->ExceptionClear();
+        
+        jclass throwable_class = env->FindClass("java/lang/Throwable");
+        jmethodID mid_throwable_getCause =
+        env->GetMethodID(throwable_class,
+                         "getCause",
+                         "()Ljava/lang/Throwable;");
+        jmethodID mid_throwable_getStackTrace =
+        env->GetMethodID(throwable_class,
+                         "getStackTrace",
+                         "()[Ljava/lang/StackTraceElement;");
+        jmethodID mid_throwable_toString =
+        env->GetMethodID(throwable_class,
+                         "toString",
+                         "()Ljava/lang/String;");
+        
+        jclass frame_class = env->FindClass("java/lang/StackTraceElement");
+        jmethodID mid_frame_toString =
+        env->GetMethodID(frame_class,
+                         "toString",
+                         "()Ljava/lang/String;");
+        
+        
+        std::string error_msg; // Could use ostringstream instead.
+        
+        _append_exception_trace_messages(*env,
+                                         error_msg,
+                                         exception,
+                                         mid_throwable_getCause,
+                                         mid_throwable_getStackTrace,
+                                         mid_throwable_toString,
+                                         mid_frame_toString);
+        cout << error_msg;
+        
+        va_list ap;
+        va_start(ap, numCleanups);
+        for(int i=0;i<numCleanups;i++)
+        {
+            env->DeleteLocalRef(va_arg(ap, jobject));
+            if(exceptionCheck(env,0))
+            {
+                cout << "NFG on Cleanup";
+            }
+        }
+        va_end(ap);
+        
+        return true;
+        
+        
+    }
+    
+    
+    return false;
+}
+
+/**
+ cleans up jobjects in long jni sequences
+ @parameter env - the JNI Environment
+ @parameter numCleanups - the number of open objects to delete
+ @parameter ... - cvariable list of objects to delete local reference
+ 
+ */
+void IVirtualMachine::cleanUpObjects(JNIEnv * env,int numCleanups,...)
+{
+    va_list ap;
+    va_start(ap, numCleanups);
+    for(int i=0;i<numCleanups;i++)
+    {
+        env->DeleteLocalRef(va_arg(ap, jobject));
+        if(exceptionCheck(env,0))
+        {
+            //DBG("NFG on Cleanup");
+        }
+    }
+    va_end(ap);
+    
+}
+
+
 // These are c to c++ API, making our IVirtualMAchine functions available to MXJ code
 
 inline IVirtualMachine* real(ivirtualmachine* d) { return static_cast<IVirtualMachine*>(d); }
@@ -666,7 +918,11 @@ extern "C" {
     void add_java_classpath(ivirtualmachine* v,char * classpath){(real(v))->addClassPath(string(classpath));}
     JavaVM * get_java_vm(ivirtualmachine* v){return real(v)->getJVM();}
     JNIEnv * get_thread_env(ivirtualmachine* v){return real(v)->attachJNIThread();}
-
+    jstring get_system_property(ivirtualmachine* v,char * property)
+    {
+        string myProp(property);
+        return real(v)->getSystemProperty(myProp);
+    }
 }
 
 #ifdef WIN_VERSION

--- a/source/mxj/IVirtualMachine.h
+++ b/source/mxj/IVirtualMachine.h
@@ -84,7 +84,10 @@ public:
 	
 	/** The constructed option string */
 	char  			*libraryPathString;
-
+    bool exceptionCheck(JNIEnv * env,int numCleanups,...);
+    void cleanUpObjects(JNIEnv * env,int numCleanups,...);
+    static jstring getSystemProperty(string propertyName);
+    
 protected:
 
 	bool launchJVM();
@@ -137,6 +140,7 @@ protected:
 	static IVirtualMachine *instance;
 
 private:
+    
     
     /** we are a singleton so our cunstructor is private */
 	IVirtualMachine();

--- a/source/mxj/IVirtualMachineAPI.h
+++ b/source/mxj/IVirtualMachineAPI.h
@@ -24,6 +24,7 @@ extern "C" {
     void add_java_classpath(ivirtualmachine* v,char * classpath);
     JavaVM * get_java_vm(ivirtualmachine* v);
     JNIEnv * get_thread_env(ivirtualmachine* v);
+    jstring get_system_property(ivirtualmachine* v,char * property);
     
 #ifdef __cplusplus
 }

--- a/source/mxj/maxjava.c
+++ b/source/mxj/maxjava.c
@@ -71,6 +71,11 @@ void awt_init_func(void);
 // Carbon/Swing modal dialog fix
 int g_in_java_modal_dialog = false;
 
+//do we need the awt hack?
+//we need the hack only in the case java is 1.6
+//let's default to true
+bool awt_hack_required = true;
+
 #endif // MAC_VERSION
 
 #ifdef WIN_VERSION
@@ -336,6 +341,9 @@ t_mxj_err call_constructor_with_coercion(t_maxjava *x, jmethodID cid, t_symbol *
  */
 JNIEnv *jvm_new(long *exists);
 
+/*new ivritual machine interface */
+ivirtualmachine * ivm = NULL;
+
 /*
  * Max is exiting.  If we've allocated a JVM, destroy it.
  */
@@ -581,7 +589,7 @@ void *maxjava_new(t_symbol *s, short argc, t_atom *argv)
 		PMO_CFRunLoopStop = (t_mp) CFBundleGetFunctionPointerForName(c_bundle, CFSTR("CFRunLoopStop"));	
 		
 		rl = PMO_GetCFRunLoopFromEventLoop(PMO_GetCurrentEventLoop());
-		if (!exists) { // only do this for the first one of mxj or mxj~ loaded -jkc
+		if (!exists && awt_hack_required) { // only do this for the first one of mxj or mxj~ loaded -jkc
 			t_symbol *ps_sched_disablequeue = gensym("sched_disablequeue"); 
 			method sched_disablequeue = (method) ps_sched_disablequeue->s_thing; 
 			long oldval; 
@@ -2606,7 +2614,7 @@ JNIEnv *jvm_new(long *exists) {
 		cp_post_system_classpath(ps);	
 		
         //grab an IVirtualMachine
-        ivirtualmachine * ivm = new_virtualmachine();
+        ivm = new_virtualmachine();
 		post("IVirtual Machine boot");
         //populate java options
         
@@ -2640,8 +2648,79 @@ JNIEnv *jvm_new(long *exists) {
     	}
     
         env = get_thread_env(ivm);
-	 
-	 	ps_global_jvm->s_thing = (t_object *)g_jvm;
+        //let's grab system properties
+        //and post them out
+        if(env != NULL)
+        {
+            jstring java_version        = get_system_property(ivm, "java.version");
+            jstring java_spec_version   = get_system_property(ivm, "java.specification.version");
+            jstring os_arch             = get_system_property(ivm, "os.arch");
+            jstring os_name             = get_system_property(ivm, "os.name");
+            jstring os_version          = get_system_property(ivm, "os.version");
+            
+            if(java_version != NULL)
+            {
+                const char * jversion = (*env)->GetStringUTFChars(env,java_version,0);
+                post("Installed Java Version :");
+                post(jversion);
+                
+                (*env)->ReleaseStringUTFChars(env,java_version,jversion);
+            }
+            
+            if(java_spec_version!=NULL)
+            {
+                const char * jspecversion = (*env)->GetStringUTFChars(env,java_spec_version,0);
+                post("Java Specification Version :");
+                post(jspecversion);
+                
+                //we switch out awt hack here
+                if(strcmp(jspecversion, "1.6")==0)
+                    awt_hack_required=true;
+                else
+                    awt_hack_required=false;
+                
+                (*env)->ReleaseStringUTFChars(env,java_spec_version,jspecversion);
+
+            
+            }
+            
+            if(os_name!=NULL)
+            {
+                const char * osname = (*env)->GetStringUTFChars(env,os_name,0);
+                post("OS Name : ");
+                post(osname);
+                
+                (*env)->ReleaseStringUTFChars(env,os_name,osname);
+
+            }
+            
+            if(os_version!=NULL)
+            {
+                const char * osversion = (*env)->GetStringUTFChars(env,os_version,0);
+                post("OS Version : ");
+                post(osversion);
+                
+                (*env)->ReleaseStringUTFChars(env,os_version,osversion);
+
+                
+            }
+
+            if(os_arch!=NULL)
+            {
+                const char * osarch = (*env)->GetStringUTFChars(env,os_arch,0);
+                post("OS Architecture : ");
+                post(osarch);
+                
+                (*env)->ReleaseStringUTFChars(env,os_arch,osarch);
+
+                
+            }
+
+            
+        }
+	 	
+        
+        ps_global_jvm->s_thing = (t_object *)g_jvm;
 	    
 	    for(i = 0; i < numOptions;i++)
 	    	sysmem_freeptr(options[i].optionString);	


### PR DESCRIPTION
This is a fix for spinning wheel of death, we removed the AWT hack in cases where the java spec version is not 1.6, it is possible that the threading that was required in Apple's 1.6 does not quite work in openjdk ./ Oracle Java, this is yet to be seen, it may be that when awt loads up the threading is looked after by the native libraries.  This also prints some more verbose info on boot up about the java environment, I have also begun to review JLI aware launchers (aka the java binary) and made some alterations based on the way oracle does the launch.  Eventually we would like to be fully "JLI Aware" launcher but this will require some more study and metamorphosis. #39 #38 are addressed here
