### PR TITLE
Spurious comma removed from package-info.json.

### DIFF
--- a/package-info.json
+++ b/package-info.json
@@ -28,5 +28,5 @@
 ,
 	"tags" : [ "java" ],
 	"version" : "7.2.5",
-	"website" : "http://www.cycling74.com",
+	"website" : "http://www.cycling74.com"
 }


### PR DESCRIPTION
(Max was complaining to console when automated via Ruby test script.)
