### PR TITLE
warning messages for lack of 32 bit java support on OSX Sierra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ build
 *.sdf
 *.suo
 sysbuild
+
+.DS_Store
+
+

--- a/source/mxj/IVirtualMachine.cpp
+++ b/source/mxj/IVirtualMachine.cpp
@@ -922,6 +922,8 @@ extern "C" {
         string myProp(property);
         return real(v)->getSystemProperty(myProp);
     }
+    bool is64BitArchitecture(ivirtualmachine* v){return real(v)->is64BitArchitecture();}
+    int getMajorOSVersion(ivirtualmachine* v){return real(v)->majorOSVersion();}
 }
 
 #ifdef WIN_VERSION
@@ -959,3 +961,26 @@ void IVirtualMachine::logLastError(LPTSTR lpszFunction){
 }
 
 #endif
+
+
+bool IVirtualMachine::is64BitArchitecture()
+{
+    bool retval = false;
+#ifdef MAC_VERSION
+    OSXSys q;
+    retval = q.is64BitRunning();
+#endif
+    return retval;
+}
+int IVirtualMachine::majorOSVersion()
+{
+    
+    int retval = 0 ;
+#ifdef MAC_VERSION
+    OSXSys q;
+    retval = q.getMajorOSVersion();
+#endif
+    return retval;
+}
+
+

--- a/source/mxj/IVirtualMachine.h
+++ b/source/mxj/IVirtualMachine.h
@@ -30,6 +30,7 @@
 #include <JavaVM/jni.h>
 #include <unistd.h>
 #include <strings.h>
+#include "OSXSys.h"
 extern "C"{
 #include "JavaHomeOsx.h"
 }
@@ -87,6 +88,8 @@ public:
     bool exceptionCheck(JNIEnv * env,int numCleanups,...);
     void cleanUpObjects(JNIEnv * env,int numCleanups,...);
     static jstring getSystemProperty(string propertyName);
+    bool is64BitArchitecture();
+    int majorOSVersion();
     
 protected:
 

--- a/source/mxj/IVirtualMachineAPI.h
+++ b/source/mxj/IVirtualMachineAPI.h
@@ -25,6 +25,8 @@ extern "C" {
     JavaVM * get_java_vm(ivirtualmachine* v);
     JNIEnv * get_thread_env(ivirtualmachine* v);
     jstring get_system_property(ivirtualmachine* v,char * property);
+    bool is64BitArchitecture(ivirtualmachine* v);
+    int getMajorOSVersion(ivirtualmachine* v);
     
 #ifdef __cplusplus
 }

--- a/source/mxj/OSXSys.h
+++ b/source/mxj/OSXSys.h
@@ -1,0 +1,28 @@
+//
+//  OSXSys.mm
+//  MAX MXJ
+//
+//  Created by PJ Slack on March 28 2017
+//  Copyright 2017 MAPLEPOST
+//  See attached MIT License
+// TODO : if winodws implemetation is neccesarry expand functions to include windows particulars
+// this version is to address a critical issues on OSX that has no support for 32 bit
+//
+
+class OSXSys {
+public:
+
+    OSXSys();
+
+    /** returns true if running in 64 bit mode, only works for OSX currently, will always return fals on windows */
+    bool is64BitRunning();
+    /** this is poulated when the object is created with the version string */
+    char osrelease[256];
+    /** converts the version string to extract an int representing the major version number */
+    int getMajorOSVersion();
+
+private:
+    int majorOSVersion;
+    
+    
+};

--- a/source/mxj/OSXSys.mm
+++ b/source/mxj/OSXSys.mm
@@ -1,0 +1,75 @@
+//
+//  OSXSys.mm
+//  MAX MXJ
+//
+//  Created by PJ Slack on March 28 2017
+//  Copyright 2017 MAPLEPOST
+//  See attached MIT License
+//
+
+#include "OSXSys.h"
+#import <Foundation/NSBundle.h>
+#import <Appkit/NSRunningApplication.h>
+#include <errno.h>
+#include <sys/sysctl.h>
+#include <string>
+
+bool OSXSys::is64BitRunning(){
+
+	switch ([[NSRunningApplication currentApplication] executableArchitecture]) {
+		case NSBundleExecutableArchitectureI386:
+			return false;
+			break;
+			
+		case NSBundleExecutableArchitectureX86_64:
+			return true;
+			break;
+			
+		case NSBundleExecutableArchitecturePPC:
+			return false;
+			break;
+			
+		case NSBundleExecutableArchitecturePPC64:
+			return true;
+			break;
+			
+		default:
+			return false;
+			break;
+	}
+    
+	
+}
+
+
+OSXSys::OSXSys()
+{
+
+    
+    size_t size = sizeof(osrelease);
+    bzero(osrelease,size);
+    majorOSVersion = 0 ;
+    int ret = sysctlbyname("kern.osrelease", osrelease, &size, NULL, 0);
+    
+    //non zero is an error
+    if(ret != 0)
+    {
+    
+    }
+    else
+    {
+        std::string s(osrelease);
+        std::string delimiter = ".";
+        std::string token = s.substr(0, s.find(delimiter));
+        majorOSVersion=atoi(token.c_str());
+        
+    }
+    
+    
+}
+
+
+int OSXSys::getMajorOSVersion()
+{
+    return majorOSVersion;
+}

--- a/source/mxj/maxjava.c
+++ b/source/mxj/maxjava.c
@@ -2608,6 +2608,92 @@ JNIEnv *jvm_new(long *exists) {
         //grab an IVirtualMachine
         ivm = new_virtualmachine();
 		post("IVirtual Machine boot");
+#ifdef MAC_VERSION
+        //check for OSX architecture and put up message
+        
+        bool architect = is64BitArchitecture(ivm);
+        int mosv = getMajorOSVersion(ivm);
+
+        /*
+         
+         16.x.x  macOS 10.12.x Sierra
+         15.x.x  OS X  10.11.x El Capitan
+         14.x.x  OS X  10.10.x Yosemite
+         13.x.x  OS X  10.9.x  Mavericks
+         12.x.x  OS X  10.8.x  Mountain Lion
+         11.x.x  OS X  10.7.x  Lion
+         10.x.x  OS X  10.6.x  Snow Leopard
+         9.x.x  OS X  10.5.x  Leopard
+         8.x.x  OS X  10.4.x  Tiger
+         7.x.x  OS X  10.3.x  Panther
+         6.x.x  OS X  10.2.x  Jaguar
+         5.x    OS X  10.1.x  Puma
+         
+         */
+        
+        switch( mosv)
+        {
+            case 16:
+                post("Sierra OSX detected");
+                break;
+            case 15:
+                post("El Capitan OSX detected");
+                break;
+            case 14:
+                post("Yosemite OSX detected");
+                break;
+            case 13:
+                post("Mavericks OSX detected");
+                break;
+            case 12:
+                post("Mountain Lion OSX detected");
+                break;
+            case 11:
+                post("Lion OSX detected");
+                break;
+            case 10:
+                post("Snow Leopard OSX detected");
+                break;
+            case 9:
+                post("Leopard OSX detected");
+                break;
+            case 8:
+                post("Tiger OSX detected");
+                break;
+            case 7:
+                post("Panther OSX detected");
+                break;
+            case 6:
+                post("Jaguar OSX detected");
+                break;
+            case 5:
+                post("Puma OSX detected");
+                break;
+            
+        
+        }
+        
+        if(! architect)
+        {
+            
+            if( mosv >= 16)
+            {
+                post("32 bit Java is not supported on Sierra and later");
+                post("please install 64 bit Java SDK and use 64 bit mode of MAX MSP");
+            }
+            if(mosv < 16)
+            {
+                post("WARNING: 32 bit detected");
+                post("Apple legacy Java will be required to operate in 32 bit mode");
+            
+            }
+            
+        }else
+        {
+            post("64 bit Architecture detected");
+        }
+        
+#endif
         //populate java options
         
         for(int i=0;i<numOptions;i++)

--- a/source/mxj/mxj.xcodeproj/project.pbxproj
+++ b/source/mxj/mxj.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		6A0A17431BD2C7A50050BF01 /* IVirtualMachine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A0A17411BD2C7A50050BF01 /* IVirtualMachine.cpp */; };
 		6A0A175A1BD317B00050BF01 /* JavaHomeOsx.c in Sources */ = {isa = PBXBuildFile; fileRef = 6A0A17581BD317B00050BF01 /* JavaHomeOsx.c */; };
 		6A0A175B1BD317B00050BF01 /* JavaHomeOsx.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A0A17591BD317B00050BF01 /* JavaHomeOsx.h */; };
+		759B84411E8AE71D001D3A53 /* OSXSys.h in Headers */ = {isa = PBXBuildFile; fileRef = 759B843F1E8AE71D001D3A53 /* OSXSys.h */; };
+		759B84421E8AE71D001D3A53 /* OSXSys.mm in Sources */ = {isa = PBXBuildFile; fileRef = 759B84401E8AE71D001D3A53 /* OSXSys.mm */; };
 		93BB3F6B12843A14000B77A5 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93BB3F6A12843A14000B77A5 /* Cocoa.framework */; };
 /* End PBXBuildFile section */
 
@@ -92,6 +94,8 @@
 		6A0A17441BD2DD350050BF01 /* IVirtualMachineAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IVirtualMachineAPI.h; sourceTree = "<group>"; };
 		6A0A17581BD317B00050BF01 /* JavaHomeOsx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = JavaHomeOsx.c; sourceTree = "<group>"; };
 		6A0A17591BD317B00050BF01 /* JavaHomeOsx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaHomeOsx.h; sourceTree = "<group>"; };
+		759B843F1E8AE71D001D3A53 /* OSXSys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSXSys.h; sourceTree = "<group>"; };
+		759B84401E8AE71D001D3A53 /* OSXSys.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSXSys.mm; sourceTree = "<group>"; };
 		8D01CCD20486CAD60068D4B7 /* mxj.mxo */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = mxj.mxo; sourceTree = BUILT_PRODUCTS_DIR; };
 		93BB3F6A12843A14000B77A5 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
@@ -162,6 +166,8 @@
 		0F2313A2098AD9D0007E8020 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				759B843F1E8AE71D001D3A53 /* OSXSys.h */,
+				759B84401E8AE71D001D3A53 /* OSXSys.mm */,
 				6A0A17401BD2C7A50050BF01 /* IVirtualMachine.h */,
 				6A0A17411BD2C7A50050BF01 /* IVirtualMachine.cpp */,
 				0F2313C2098ADAD8007E8020 /* Atom.c */,
@@ -233,6 +239,7 @@
 				0F2313F6098ADBD7007E8020 /* clock_callbacks.h in Headers */,
 				0F2313FA098ADBE4007E8020 /* callbacks.h in Headers */,
 				0F2313FE098ADE42007E8020 /* mxj_macho_prefix.h in Headers */,
+				759B84411E8AE71D001D3A53 /* OSXSys.h in Headers */,
 				0FCF77C3098AF49B006F07A0 /* classes.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -322,6 +329,7 @@
 				0F2313E1098ADB61007E8020 /* mxj_wind.c in Sources */,
 				0F2313E5098ADB6C007E8020 /* mxj_patcher.c in Sources */,
 				0F2313E9098ADB8B007E8020 /* mxj_utils.c in Sources */,
+				759B84421E8AE71D001D3A53 /* OSXSys.mm in Sources */,
 				0F2313ED098ADBAE007E8020 /* mxj_msp_buffer.c in Sources */,
 				0F2313F1098ADBCA007E8020 /* mxj_max_system.c in Sources */,
 				0F2313F5098ADBD7007E8020 /* clock_callbacks.c in Sources */,

--- a/source/mxj/mxj~.xcodeproj/project.pbxproj
+++ b/source/mxj/mxj~.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		6A0A17641BD3FE9D0050BF01 /* IVirtualMachineAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A0A175F1BD3FE9D0050BF01 /* IVirtualMachineAPI.h */; };
 		6A0A17651BD3FE9D0050BF01 /* JavaHomeOsx.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A0A17601BD3FE9D0050BF01 /* JavaHomeOsx.h */; };
 		6A0A17661BD3FE9D0050BF01 /* IVirtualMachine.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A0A17611BD3FE9D0050BF01 /* IVirtualMachine.h */; };
+		759B84451E8AFFFA001D3A53 /* OSXSys.h in Headers */ = {isa = PBXBuildFile; fileRef = 759B84431E8AFFFA001D3A53 /* OSXSys.h */; };
+		759B84461E8AFFFA001D3A53 /* OSXSys.mm in Sources */ = {isa = PBXBuildFile; fileRef = 759B84441E8AFFFA001D3A53 /* OSXSys.mm */; };
+		759B84491E8B211F001D3A53 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 759B84481E8B211F001D3A53 /* Cocoa.framework */; };
 		8D01CCCE0486CAD60068D4B7 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08EA7FFBFE8413EDC02AAC07 /* Carbon.framework */; };
 /* End PBXBuildFile section */
 
@@ -95,6 +98,9 @@
 		6A0A175F1BD3FE9D0050BF01 /* IVirtualMachineAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IVirtualMachineAPI.h; sourceTree = "<group>"; };
 		6A0A17601BD3FE9D0050BF01 /* JavaHomeOsx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaHomeOsx.h; sourceTree = "<group>"; };
 		6A0A17611BD3FE9D0050BF01 /* IVirtualMachine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IVirtualMachine.h; sourceTree = "<group>"; };
+		759B84431E8AFFFA001D3A53 /* OSXSys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSXSys.h; sourceTree = "<group>"; };
+		759B84441E8AFFFA001D3A53 /* OSXSys.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSXSys.mm; sourceTree = "<group>"; };
+		759B84481E8B211F001D3A53 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		8D01CCD20486CAD60068D4B7 /* mxj~.mxo */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mxj~.mxo"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -103,6 +109,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				759B84491E8B211F001D3A53 /* Cocoa.framework in Frameworks */,
 				22E076901AE823D0009EC560 /* MaxAudioAPI.framework in Frameworks */,
 				8D01CCCE0486CAD60068D4B7 /* Carbon.framework in Frameworks */,
 			);
@@ -118,6 +125,7 @@
 				08FB77ADFE841716C02AAC07 /* Source */,
 				089C1671FE841209C02AAC07 /* External Frameworks and Libraries */,
 				19C28FB4FE9D528D11CA2CBB /* Products */,
+				759B84471E8B211F001D3A53 /* Frameworks */,
 			);
 			name = mxj;
 			sourceTree = "<group>";
@@ -166,6 +174,8 @@
 		0F2313A2098AD9D0007E8020 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				759B84431E8AFFFA001D3A53 /* OSXSys.h */,
+				759B84441E8AFFFA001D3A53 /* OSXSys.mm */,
 				6A0A175D1BD3FE9D0050BF01 /* JavaHomeOsx.c */,
 				6A0A175E1BD3FE9D0050BF01 /* IVirtualMachine.cpp */,
 				6A0A175F1BD3FE9D0050BF01 /* IVirtualMachineAPI.h */,
@@ -210,6 +220,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		759B84471E8B211F001D3A53 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				759B84481E8B211F001D3A53 /* Cocoa.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -224,6 +242,7 @@
 				0F2313B9098ADA7E007E8020 /* maxjava.h in Headers */,
 				0F2313C1098ADACA007E8020 /* ExceptionUtils.h in Headers */,
 				0F2313C5098ADAD8007E8020 /* Atom.h in Headers */,
+				759B84451E8AFFFA001D3A53 /* OSXSys.h in Headers */,
 				0F2313DA098ADB42007E8020 /* mxj_box.h in Headers */,
 				6A0A17641BD3FE9D0050BF01 /* IVirtualMachineAPI.h in Headers */,
 				0F2313DE098ADB4E007E8020 /* mxj_qelem.h in Headers */,
@@ -326,6 +345,7 @@
 				0F2313E1098ADB61007E8020 /* mxj_wind.c in Sources */,
 				0F2313E5098ADB6C007E8020 /* mxj_patcher.c in Sources */,
 				0F2313E9098ADB8B007E8020 /* mxj_utils.c in Sources */,
+				759B84461E8AFFFA001D3A53 /* OSXSys.mm in Sources */,
 				0F2313ED098ADBAE007E8020 /* mxj_msp_buffer.c in Sources */,
 				0F2313F1098ADBCA007E8020 /* mxj_max_system.c in Sources */,
 				0F2313F5098ADBD7007E8020 /* clock_callbacks.c in Sources */,


### PR DESCRIPTION
This is a 32 bit warning / error message hook for OSX only

This warns that java 32 bit is not available if the user is running 32 bit on Sierra
This warns that legacy java has to be installed if running 32 bit and < Sierra
This does not make any warnings if running on 64 bit other than to display OSX major version and that 64 bit architecture is sensed