### PR TITLE
Hotfix/runtime jre for apple arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 if (APPLE)
 	if (CMAKE_OSX_ARCHITECTURES STREQUAL "" 
 		OR CMAKE_OSX_ARCHITECTURES STREQUAL "i386")
-		set(CMAKE_OSX_ARCHITECTURES x86_64) # override the old max-api values permitting i386
+		set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64") # override the old max-api values permitting i386
 	endif ()
 	if (CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
 		set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ jre/Contents/Plugins
 jre/Contents/Resources
 jre/Contents/Frameworks
 
+If you want to use a zulu jre, you must extract its content to match the above structure.
+
 The JRE can be found here after installing a java internet plugin:
 "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/"
 Copy that folder and rename it "jre"

--- a/README.md
+++ b/README.md
@@ -29,11 +29,20 @@ Use the badges above to go directly to the CI services.
 
 
 ## To build (Windows)
-Download the Windows x86 Java SE Development Kit 8 (from http://www.oracle.com and install it in the default location (C:\Program Files (x86)\Java). Rename 'C:\Program Files (x86)\Java\jdk1.8.0_xxx' to 'C:\Program Files (x86)\Java\jdk1.8.0'.
+Download the Windows x64 Java SE Development Kit 8 (from http://www.oracle.com and install it in the default location (C:\Program Files\Java).
 
 Download and install Cmake.
+Define variable JAVA_HOME with `rundll32.exe sysdm.cpl,EditEnvironmentVariables`
+* JAVA_HOME => "C:\Program Files\Java\jdk1.8.0_xxx"
 
-Build as on macOS.
+* after that, launch a new shell, then from max-mxj folder:
+* `mkdir build`
+* `cd build`
+* `set CUSTOM_FLAG="-DWIN64:Bool=True"`
+* `cmake -G "Visual Studio 15 2017 Win64" ..`  (update version according to your Visual studio version, Win64 is mandatory)
+* `cmake --build .` (or open the VS project in this build folder and build there)
+* `cmake --build . --config Release`
+
 
 ## MXJ rules for searching for Java:
 

--- a/README.md
+++ b/README.md
@@ -36,20 +36,43 @@ Download and install Cmake.
 Build as on macOS.
 
 ## MXJ rules for searching for Java:
-On OSX, it searches in that order: embeded JRE, on system JDK, on system JRE
-The search for an embeded JRE is done in the application, in the folder MyApp.app/Contents/Resources/C74/packages/max-mxj/jre
-The JRE must have the structure :
+
+### MacOS
+On OSX, it searches in that order: embedded JRE, on system JDK, on system JRE.
+
+The search for an embedded JRE is done in the application, in the folder MyApp.app/Contents/Resources/C74/packages/max-mxj/jre
+The JRE must have the structure for a single architecture:
 jre/Contents/Home
 jre/Contents/MacOS
 jre/Contents/Plugins
 jre/Contents/Resources
 jre/Contents/Frameworks
 
+For MacOS universal application, you must either use an universal JRE (no one seems to be available at the moment), or use one JRE per architecture:
+jre/jre_x64/Contents/Home
+jre/jre_x64/Contents/MacOS
+jre/jre_x64/Contents/Plugins
+jre/jre_x64/Contents/Resources
+jre/jre_x64/Contents/Frameworks
+jre/jre_aarch64/Contents/Home
+jre/jre_aarch64/Contents/MacOS
+jre/jre_aarch64/Contents/Plugins
+jre/jre_aarch64/Contents/Resources
+jre/jre_aarch64/Contents/Frameworks
+
 If you want to use a zulu jre, you must extract its content to match the above structure.
 
 The JRE can be found here after installing a java internet plugin:
 "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/"
-Copy that folder and rename it "jre"
+Copy that folder and rename it "jre".
 
-On Windows, it searches in that order: embeded JRE, on system JDK, on system JRE
-The search for an embeded JRE is done in the application, it must be a folder named "jre" placed in the same folder as the application .exe 
+### Windows
+On Windows, it searches in that order: embedded JRE, on system JDK, on system JRE
+The search for an embedded JRE is done in the application, it must be a folder named "jre" placed in the same folder as the application .exe 
+
+### JDK/JRE providers:
+https://adoptium.net/temurin/releases/
+https://adoptopenjdk.net/releases.html
+https://www.oracle.com/java/technologies/downloads/
+
+You can download a zipped version and rename the unzipped folder according to the requirements.

--- a/source/mxj/IVirtualMachine.cpp
+++ b/source/mxj/IVirtualMachine.cpp
@@ -254,9 +254,8 @@ void IVirtualMachine::startJVM()
 
 
 	char * baseDir = getJavaHome();
-	char * dylib = findLib(baseDir);
-	char * jli = getJavaJli();
-
+	char * dylib;
+	char * jli;
 
 	//we look to the environment for an embedded path
 	char * embeddedEnvironment = getenv("EMBEDDED_JVM_LIBRARY_PATH");
@@ -264,11 +263,14 @@ void IVirtualMachine::startJVM()
 
 	if(embeddedEnvironment!=NULL)
 		dylib = embeddedEnvironment;
+	else 
+		dylib = findLib(baseDir);
 
 	//embedded users must also provide the full path to the JLI library
 	if(embeddedJliEnvironment!=NULL)
 		jli = embeddedJliEnvironment;
-
+	else
+		jli = getJavaJli();
 
 	//the jvm can still launch if jli is not present
 	//in the case of Apple java 1.6 for example this will not result in a problem

--- a/source/mxj/IVirtualMachine.cpp
+++ b/source/mxj/IVirtualMachine.cpp
@@ -280,9 +280,10 @@ void IVirtualMachine::startJVM()
 	if(dylib!=NULL)
 	{
 
-		handle= dlopen(dylib,RTLD_NOW + RTLD_GLOBAL);
-		if(handle==NULL)
+		handle = dlopen(dylib, RTLD_NOW + RTLD_GLOBAL);
+		if (handle == NULL)
 		{
+			error("Cannot open dylib: %s", dlerror());
 			return;
 		}
 	}

--- a/source/mxj/JavaHomeOsx.c
+++ b/source/mxj/JavaHomeOsx.c
@@ -109,10 +109,6 @@ static bool privateEmbeddedHomeDirectorySearched = false; // Search already done
 // (folder jre in max-mxj package)
 char *getEmbeddedHomeDirectory()
 {
-    //for osx we only look at embedded binaries for 64 bit
-#if !defined(__x86_64__)
-    return NULL;
-#else
     if (!privateEmbeddedHomeDirectorySearched) // Search embedded jre if not searched yet
     {
         privateEmbeddedHomeDirectorySearched = true;
@@ -161,7 +157,6 @@ char *getEmbeddedHomeDirectory()
         }
     }
     return privateEmbeddedHomeDirectory;
-#endif
 }
 
 

--- a/source/projects/mxj-common.cmake
+++ b/source/projects/mxj-common.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 if (APPLE)
 	if (CMAKE_OSX_ARCHITECTURES STREQUAL "" 
 		OR CMAKE_OSX_ARCHITECTURES STREQUAL "i386")
-		set(CMAKE_OSX_ARCHITECTURES x86_64) # override the old max-api values permitting i386
+		set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64") # override the old max-api values permitting i386
 	endif ()
 	if (CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
 		set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)

--- a/source/projects/mxj_safe/CMakeLists.txt
+++ b/source/projects/mxj_safe/CMakeLists.txt
@@ -11,7 +11,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmak
 if (APPLE)
 	if (CMAKE_OSX_ARCHITECTURES STREQUAL "" 
 		OR CMAKE_OSX_ARCHITECTURES STREQUAL "i386")
-		set(CMAKE_OSX_ARCHITECTURES x86_64) # override the old max-api values permitting i386
+		set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64") # override the old max-api values permitting i386
 	endif ()
 	if (CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
 		set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)


### PR DESCRIPTION
Hi,
My changes concerns only macOS. They enable JRE embedding for Apple M1 architecture.
I also updated readme file for that purpose, and also Windows building procedure.

(however I am not able to build a proper running mxj for windows, even from your branch, i probably lack some instructions, if you can provide some help, i'll check my build on Windows).
